### PR TITLE
Backup option for os10_config module, leaves string "show running-configuration" in the backup file 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: os10
 namespace: dellemc_networking
 readme: README.md
 tags: [dell, dellemc, os10, emc, networking]
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/ansible-collections/dellemc_networking.os10
 documentation: https://github.com/ansible-collections/dellemc_networking.os10/tree/master/docs
 homepage: https://github.com/ansible-collections/dellemc_networking.os10

--- a/plugins/module_utils/network/os10.py
+++ b/plugins/module_utils/network/os10.py
@@ -78,7 +78,7 @@ def check_args(module, warnings):
 def get_config(module, flags=None):
     flags = [] if flags is None else flags
 
-    cmd = 'show running-config '
+    cmd = 'show running-configuration'
     cmd += ' '.join(flags)
     cmd = cmd.strip()
 


### PR DESCRIPTION

Problem:
When user creates a backup configuration with the following playbook, the backup config file additionally
includes string "show running-configuration" in it.This prevents using the config file later to apply in switch.


hosts: leaf
gather_facts: No
vars:
output_dir: "/root/switch_dump/"
collections:
-dellemc_networking.os10
tasks:

name: dump switch config
os10_config:
backup: yes
backup_options:
filename: "{{ inventory_hostname }}.cfg"
dir_path: "{{ output_dir }}"



Root cause:
In Ansible core module, there is a code to remove "show running-configuration" from the file, if the command
"show running-configuration" was executed.But in out get-config, we have the command to be executed as "show running-config",
which prevents the string from getting removed.
Fix:
Changed the command to be executed from "show running-config" to "show running-configuration"
UT:
Ran the problematic playbook and no issue was observed.